### PR TITLE
Make xcpretty available on mojave-xcode images

### DIFF
--- a/templates/mojave-xcode.json
+++ b/templates/mojave-xcode.json
@@ -18,7 +18,7 @@
   "provisioners": [
     {
       "inline": [
-        "sudo gem install bundler fastlane cocoapods rake -NV",
+        "sudo gem install bundler fastlane cocoapods rake xcpretty -NV",
         "pod setup"
       ],
       "type": "shell"


### PR DESCRIPTION
Looks like there aren't much dependencies so hopefully it's ok. If the image builds xcode, it should output xcode outputs cleanly :)