### PR TITLE
Fix: Comma typos in catalina-base.json, remove anka --protocol tcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ packer build templates/catalina-base.json
 We also need to add a port forwarding rule so VMs based of `catalina-base` image can be SSHable:
 
 ```bash
-anka modify catalina-base add port-forwarding --host-port 0 --guest-port 22 --protocol tcp ssh
+anka modify catalina-base add port-forwarding --host-port 0 --guest-port 22 ssh
 ```
 
 ## Building Xcode Images

--- a/templates/catalina-base.json
+++ b/templates/catalina-base.json
@@ -63,9 +63,9 @@
     {
       "inline": [
         "sudo safaridriver --enable",
-        "networksetup -setdnsservers Ethernet 8.8.8.8 8.8.4.4 1.1.1.1",
+        "networksetup -setdnsservers Ethernet 8.8.8.8 8.8.4.4 1.1.1.1"
       ],
       "type": "shell"
-    },
+    }
   ]
 }


### PR DESCRIPTION
anka modify catalina-base add port-forwarding --host-port 0 --guest-port 22 --protocol tcp ssh
Error: no such option: --protocol

And the commas are not syntactically workable.