### PR TITLE
Disable automatic brew cleanup

### DIFF
--- a/anka/templates/big-sur-base.json
+++ b/anka/templates/big-sur-base.json
@@ -30,6 +30,7 @@
         "echo \"export LANG=en_US.UTF-8\" >> ~/.profile",
         "echo \"export PATH=/usr/local/bin:$PATH\" >> ~/.profile",
         "echo \"export HOMEBREW_NO_AUTO_UPDATE=1\" >> ~/.profile",
+        "echo \"export HOMEBREW_NO_INSTALL_CLEANUP=1\" >> ~/.profile",
         "source ~/.profile"
       ],
       "type": "shell"

--- a/anka/templates/catalina-base.json
+++ b/anka/templates/catalina-base.json
@@ -30,6 +30,7 @@
         "echo \"export LANG=en_US.UTF-8\" >> ~/.profile",
         "echo \"export PATH=/usr/local/bin:$PATH\" >> ~/.profile",
         "echo \"export HOMEBREW_NO_AUTO_UPDATE=1\" >> ~/.profile",
+        "echo \"export HOMEBREW_NO_INSTALL_CLEANUP=1\" >> ~/.profile",
         "source ~/.profile"
       ],
       "type": "shell"


### PR DESCRIPTION
Cleanup fires after "brew install" when 30 days have passed, which is
likely to be the case on the prebuilt images.